### PR TITLE
Use the base image (gclub/skywardai) instead and change the working directory to /app.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,35 +1,20 @@
-# Pull official latest Python Docker image (Pulished with version 3.11.0)
-FROM --platform=linux/amd64 python:latest
+# Pull gclub/skywardai:0.0.1 base image (Base on Python 3.11.0-slim)
+FROM docker.io/gclub/skywardai:0.0.1
 
 # Set the working directory
-WORKDIR /usr/backend
-
-# Set up Python behaviour
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-ENV VIRTUAL_ENV=/opt/venv
+WORKDIR /app
 
 # Set the server port
 EXPOSE 8000
 
-# Install system dependencies
-RUN apt-get update \
-  && apt-get -y install netcat-traditional gcc postgresql \
-  && apt-get clean
-
-# Install Python dependencies
-COPY ./requirements.txt ./
-RUN pip3 install -r requirements.txt
-
 # Copy all files
 COPY . .
 
-# Copy entrypoint.sh for auto connection with account_db service
-COPY ./entrypoint.sh .
-RUN chmod +x /usr/backend/entrypoint.sh
+# Add execution permissions to entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
-# Execute entrypoint.sh
-ENTRYPOINT ["/usr/backend/entrypoint.sh" ]
+# Execute entrypoint.sh for check connection with account_db service
+ENTRYPOINT ["/app/entrypoint.sh" ]
 
 # Start up the backend server
 CMD uvicorn src.main:backend_app --reload --workers 4 --host 0.0.0.0 --port 8000


### PR DESCRIPTION
Use the base image (gclub/skywardai) instead and change the working directory to /app.

**Description**

Use base images to reduce build steps and build time.
The Image working directory is unified into the /app directory that is commonly used in open source projects.
This PR fixes #57

**Notes for Reviewers**


**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
