### PR TITLE
fix:fix the validation error of external confi not allowed

### DIFF
--- a/backend/src/config/settings/development.py
+++ b/backend/src/config/settings/development.py
@@ -6,3 +6,16 @@ class BackendDevSettings(BackendBaseSettings):
     DESCRIPTION: str | None = "Development Environment."
     DEBUG: bool = True
     ENVIRONMENT: Environment = Environment.DEVELOPMENT
+    BACKEND_SERVER_HOST: str
+    BACKEND_SERVER_PORT: int
+    BACKEND_SERVER_WORKERS: int
+    POSTGRES_DB: str
+    POSTGRES_PASSWORD: str
+    POSTGRES_PORT: int
+    POSTGRES_SCHEMA: str
+    POSTGRES_USERNAME: str
+    POSTGRES_HOST: str
+    POSTGRES_URI: str
+    ETCD_AUTO_COMPACTION_MODE: str
+    ETCD_AUTO_COMPACTION_RETENTION: str
+    ETCD_QUOTA_BACKEND_BYTES: str


### PR DESCRIPTION
**Description**

This PR fixes the error message of validation for external configs not allowed when build in local

**Notes for Reviewers**


**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
