### PR TITLE
feat/add api of listing used datasets

### DIFF
--- a/backend/src/api/routes/file.py
+++ b/backend/src/api/routes/file.py
@@ -49,6 +49,18 @@ async def upload_and_return_id(
 
     return FileInResponse(fileID=new_file.id)
 
+@router.get(
+    path="/dataset",
+    name="dataset:get-dataset-list",
+    response_model=list[str],
+    status_code=fastapi.status.HTTP_200_OK,
+)
+async def get_dataset(
+) -> list[str]:
+    #TODO return the names of recently used dataset order by last used time desc
+    res = ["dataset1","dataset2"]
+
+    return res
 
 @router.get(
     path="/{id}",
@@ -66,3 +78,4 @@ async def check_status(
     # 1 for complete successfully
     # -1 for error
     return FileStatusInResponse(status=1)
+

--- a/backend/src/api/routes/train.py
+++ b/backend/src/api/routes/train.py
@@ -23,7 +23,10 @@ async def train(
     file_repo: UploadedFileCRUDRepository = fastapi.Depends(get_repository(repo_type=UploadedFileCRUDRepository)),
     rag_chat_repo: RAGChatModelRepository = fastapi.Depends(get_rag_repository(repo_type=RAGChatModelRepository)),
 ) -> TrainFileInResponse:
-
+    #TODO train can be performed by csv file or dataset
+    # 1, either fileID or dataset should be shown in input
+    # 2, validate fileID or dataset
+    # 3, use file and or dataset perform the training logic (csv id done)
     ai_model = await aimodel_repo.read_aimodel_by_id(id=train_in_msg.modelID)
     file_csv = await file_repo.read_uploadedfiles_by_id(id=train_in_msg.fileID)
 

--- a/backend/src/models/schemas/train.py
+++ b/backend/src/models/schemas/train.py
@@ -2,7 +2,8 @@ from src.models.schemas.base import BaseSchemaModel
 
 
 class TrainFileIn(BaseSchemaModel):
-    fileID: int
+    fileID: int | None = None
+    dataSet: str | None = None
     modelID: int
 
 


### PR DESCRIPTION
**Description**

This PR add one empty api  /file/dataset to list all dataset that used before and allow dataset as one optional param in api /train/

This PR is related to #95 

The corresponding logics of the two api changes are left for future implementation

**Notes for Reviewers**


**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
