### PR TITLE
Replacing repo secrets to org level secrets

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -160,9 +160,9 @@ jobs:
       - name: Build Docker image
         if: startsWith(github.ref, 'refs/tags/') != true && success()
         run: |
-          docker build -t ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.IMAGE_NAME }}:${GITHUB_SHA::7} .
+          docker build -t ${{ secrets.DOCKER_REGISTRY_KIRIN }}/${{ secrets.IMAGE_NAME_KIRIN }}:${GITHUB_SHA::7} .
       - name: Push Docker image
         if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && success()
         run: |
-          docker build -t ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.IMAGE_NAME }}:${GITHUB_REF/refs\/tags\//} .
-          docker push ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.IMAGE_NAME }}:${GITHUB_REF/refs\/tags\//}
+          docker build -t ${{ secrets.DOCKER_REGISTRY_KIRIN }}/${{ secrets.IMAGE_NAME_KIRIN }}:${GITHUB_REF/refs\/tags\//} .
+          docker push ${{ secrets.DOCKER_REGISTRY_KIRIN }}/${{ secrets.IMAGE_NAME_KIRIN }}:${GITHUB_REF/refs\/tags\//}


### PR DESCRIPTION
**Description**

This PR fixes #47 

**Notes for Reviewers**

In this PR, we replaced current secrets by using org level secrets. This can let all collaborators PR get correct permission to run GitHub Actions.

Note: The repo level secrets will be override by org level secrets. So, we will remove the same name secrets which are in repo level. (Done)


**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
