### PR TITLE
[chat-backend] Implemented issue templates and SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-issue.yml
+++ b/.github/ISSUE_TEMPLATE/1-issue.yml
@@ -1,0 +1,33 @@
+name: Issue Report
+description: File an issue report.
+title: "[Issue]: "
+labels: ["issue"]
+projects: ["SkywardAI/chat-backend"]
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this issue report.
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What is the issue you are having?
+      placeholder: Tell us your issue.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/2-feature.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yml
@@ -1,0 +1,23 @@
+name: Feature Request
+description: File a feature request.
+title: "[Feature]: "
+labels: ["feature", "improvement"]
+projects: ["SkywardAI/chat-backend"]
+assignees:
+  - octocat
+body:
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: What feature are you requesting?
+      placeholder: Tell us what your feature.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-bug.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug.yml
@@ -1,0 +1,43 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug"]
+projects: ["SkywardAI/chat-backend"]
+assignees:
+  - octocat
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report.
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what happened.
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      placeholder: Tell us your software version
+      value: "Example: 0.2.4"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: SkywardAI
+    url: https://skywardai.github.io/skywardai.io/
+    about: Please find further information and documentation here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Reporting Security Issues
+
+The SkywardAI team and community take security bugs in the various SkywardAI repositories seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/electron/electron/security/advisories/new) tab.
+
+The Electron team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining the module. You can also report a vulnerability through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability".
+
+## The Electron Security Notification Process
+
+For context on Electron's security notification process, please see the [Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md#notifications) section of the Security WG's [Membership and Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md) Governance document.
+
+## Learning More About Security
+
+To learn more about securing an Electron application, please see the [security tutorial](docs/tutorial/security.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,16 +2,8 @@
 
 The SkywardAI team and community take security bugs in the various SkywardAI repositories seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/electron/electron/security/advisories/new) tab.
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/SkywardAI/chat-backend/security/advisories/new) tab.
 
-The Electron team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+The SkywardAI team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
-Report security bugs in third-party modules to the person or team maintaining the module. You can also report a vulnerability through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability".
-
-## The Electron Security Notification Process
-
-For context on Electron's security notification process, please see the [Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md#notifications) section of the Security WG's [Membership and Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md) Governance document.
-
-## Learning More About Security
-
-To learn more about securing an Electron application, please see the [security tutorial](docs/tutorial/security.md).
+Report security bugs in third-party modules to the person or team maintaining the module. 


### PR DESCRIPTION
**Description**

This PR implements the ability to use templates for issue logging, alongside implementing a project SECURITY.md file for Github usage. 

**Notes for Reviewers**

Currently I have implemented three templates based on the existing issue lists, feature/improvement, bug and issue (bug and issue are similar and may be merged depending on the opinion of project leadership).

Please note I have elected not to write a portion on tracking of reporting security risks for the reporter, as we don't currently possess a policy detailing this to my knowledge. 

Of note as well, the PR template may be incorrect as it thanks the contributor for contributing to Meshery not SkywardAI.

**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
