### PR TITLE
[feat]: replace flake8 to ruff

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -18,9 +18,10 @@ jobs:
           - ubuntu-latest
         python-version:
           - "3.11"
-    defaults:
-      run:
-        working-directory: backend/
+    # No need to set to specific directory
+    # defaults:
+    #   run:
+    #     working-directory: backend/
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -33,13 +34,10 @@ jobs:
           cache: 'pip'
       - name: Install Dependencies for Linting
         run: |
-          pip install flake8
-      - name: Lint with Flake8
+          pip install ruff==0.4.9
+      - name: Lint with ruff
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          make ruff
 
  
   # test:

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,10 @@ gpu-logs:
 .PHONY: gpu-remove
 gpu-remove:
 	docker compose -f docker-compose.gpu.yaml down
+
+############################################################################################################
+# Linter
+
+.PHONY: ruff
+ruff:
+	@ruff check --output-format=github backend/src/ --config ruff.toml

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,53 @@
+# https://docs.astral.sh/ruff/configuration/
+
+# ignored directories
+exclude = [
+    ".devcontainer",
+    ".github",
+    ".git",
+    ".vscode",
+]
+
+
+# Same as Black
+line-length = 120
+indent-width = 4
+
+# Assume Python 3.11
+target-version = "py311"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+
+# Example of ignore files
+# Ignore `E402` (import violations) in all `__init__.py` files, and in select subdirectories.
+[lint.per-file-ignores]
+"__init__.py" = ["E402"]
+"**/{tests,docs,tools}/*" = ["E402"]
+
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"


### PR DESCRIPTION
**Description**

This PR fixes #158 

**Notes for Reviewers**

Currently, we use flake8 as the default linter, it will convert error to warning during the CI process. So, we do have many of code style issues should be fixed.

We replace flak8 to ruff because we want to keep all the repos similar. And it would be easier for us to maintain the repo.


**[Signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
